### PR TITLE
Update xcelEndpoint.py

### DIFF
--- a/xcel_itron2mqtt/xcelEndpoint.py
+++ b/xcel_itron2mqtt/xcelEndpoint.py
@@ -68,12 +68,14 @@ class xcelEndpoint():
                 for val_items in v:
                     for k2, v2 in val_items.items():
                         search_val = f'{IEEE_PREFIX}{k2}'
-                        value = root.find(f'.//{search_val}').text
-                        readings_dict[f'{k}{k2}'] = value
+                        if root.find(f'.//{search_val}') is not None:
+                            value = root.find(f'.//{search_val}').text
+                            readings_dict[f'{k}{k2}'] = value
             else:
                 search_val = f'{IEEE_PREFIX}{k}'
-                value = root.find(f'.//{IEEE_PREFIX}{k}').text
-                readings_dict[k] = value
+                if root.find(f'.//{IEEE_PREFIX}{k}') is not None:
+                    value = root.find(f'.//{IEEE_PREFIX}{k}').text
+                    readings_dict[k] = value
     
         return readings_dict
 


### PR DESCRIPTION
parse_response has an error if the XML element does not exist or does not have text.  I added an if statement to check if the element exists and not None.  My smart meter does not provide a touTier value in the XML output. I see the error below when using the xcel_itron2mqtt Home Assistant addon 

Traceback (most recent call last):
  File "/opt/xcel_itron2mqtt/main.py", line 88, in <module>
    meter.run()
  File "/opt/xcel_itron2mqtt/xcelMeter.py", line 243, in run
    obj.run()
  File "/opt/xcel_itron2mqtt/xcelEndpoint.py", line 180, in run
    reading = self.get_reading()
              ^^^^^^^^^^^^^^^^^^
  File "/opt/xcel_itron2mqtt/xcelEndpoint.py", line 88, in get_reading
    self.current_response = self.parse_response(response, self.tags)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/xcel_itron2mqtt/xcelEndpoint.py", line 75, in parse_response
    value = root.find(f'.//{IEEE_PREFIX}{k}').text
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'text'

This is an example of my meters XML response:

<Reading
     xmlns="urn:ieee:std:2030.5:ns"
     href="/upt/1/mr/2/rs/1/r/1">
    <qualityFlags>01</qualityFlags>
    <timePeriod>
        <duration>1</duration>
        <start>1712593859</start>
    </timePeriod>
    <value>0</value>
    <localID>01</localID>
</Reading>
