### PR TITLE
feat: allow env variable for mqtt prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following are options that may be passed into the container in the form of e
 | -v <path_to_cert_folder>:/opt/xcel_itron2mqtt/certs | Folder path to the certs generated with the generate keys script | NO |
 | -e MQTT_SERVER | IP address of the MQTT server to communicate with | NO |
 | -e MQTT_PORT | Port # of the MQTT server to communicate with, **Default: 1883**| yes |
+| -e MQTT_TOPIC_PREFIX | Prefix of MQTT topic set in Home Assistant, **Default: homeassistant/** | yes | 
 | -e METER_IP | IP address of the itron meter. Useful for those that run iot devices on other vlans | yes |
 | -e METER_PORT | Port number of the meter, must be set if `METER_IP` is set. **Default: 8081**| yes |
 | -e MQTT_USER | Username to authenticate to the MQTT server | yes |

--- a/xcel_itron2mqtt/xcelEndpoint.py
+++ b/xcel_itron2mqtt/xcelEndpoint.py
@@ -1,4 +1,5 @@
 import yaml
+import os
 import json
 import requests
 import logging
@@ -27,7 +28,7 @@ class xcelEndpoint():
         self.client = mqtt_client
         self.device_info = device_info
 
-        self._mqtt_topic_prefix = 'homeassistant/'
+        self._mqtt_topic_prefix = os.getenv('MQTT_TOPIC_PREFIX', 'homeassistant/')
         self._current_response = None
         self._mqtt_topic = None
         # Record all of the sensor state topics in an easy to lookup dict


### PR DESCRIPTION
It is possible to configure a different prefix for homeassistant's auto discover than the default of homeassistant. This allows a user to set this as an environment variable if they have done so.

Uses `homeassistant/` by default, but if you pass `MQTT_TOPIC_PREFIX` as a env variable we use that prefix instead

This addresses issue #30
