### PR TITLE
Update to include ARM64 Build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -39,4 +45,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This should fix https://github.com/zaknye/xcel_itron2mqtt/issues/36.  

A few small additions to the github workflow in the project and this builds for me without issue and runs on ARM64.  I managed to get the container up and running on a k3s cluster.  

Of note, this builds a single unified docker image.  Not sure if it makes sense to split it out into two separate versions or not, I'm not super clear on how all that works.  

Anyway, hope it helps.