### PR TITLE
set state_class to measurement for power sensors

### DIFF
--- a/xcel_itron2mqtt/configs/endpoints_3_2_39.yaml
+++ b/xcel_itron2mqtt/configs/endpoints_3_2_39.yaml
@@ -5,6 +5,7 @@
         entity_type: sensor
         device_class: power
         unit_of_measurement: W
+        state_class: measurement
 - Current Summation Received:
     url: '/upt/1/mr/2/rs/1/r/1'
     tags:

--- a/xcel_itron2mqtt/configs/endpoints_default.yaml
+++ b/xcel_itron2mqtt/configs/endpoints_default.yaml
@@ -5,6 +5,7 @@
         entity_type: sensor
         device_class: power
         unit_of_measurement: W
+        state_class: measurement
 - Current Summation Received:
     url: '/upt/1/mr/2/rs/1/r/1'
     tags:


### PR DESCRIPTION
I use https://github.com/wingrunr21/hassio-xcel-itron-mqtt to pull in energy data from my smart meter into Home Assistant. In the December 2025 release of Home Assistant, they added the ability to configure power sensors to the Energy dashboard, to enable monitoring of real-time power usage.

The add-on already brings in real-time energy data via the `Instantaneous Demand value` sensor provided by this repo. However, Home Assistant won't show this sensor as an option to pick in the new "Grid power" dropdown shown here:

<img width="400" height="647" alt="grid power" src="https://github.com/user-attachments/assets/fc20f486-30db-453e-b5ee-6597edd80640" />

Per https://www.home-assistant.io/docs/energy/faq/#troubleshooting-missing-entities, `state_class` must be `measurement` for power sensors and `total` or `total_increasing` for all others. This PR defines the `state_class` as `measurement` for the `Instantaneous Demand value` sensor.

I have not personally tested this, so I'm looking for feedback and help with testing, unless you think this is fine to merge as-is.